### PR TITLE
fix: update nuxt compatibility

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -28,7 +28,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Compatibility constraints
     compatibility: {
       // Semver version of supported nuxt versions
-      nuxt: '^3.0.0'
+      nuxt: '^3.0.0-rc.2'
     }
   },
   // Default configuration options for your module


### PR DESCRIPTION
In https://github.com/nuxt/framework/pull/7116 we made a breaking change allowing modules to use RC constraints. This PR fixes this.